### PR TITLE
DGL 0.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,27 +34,27 @@ The code has been tested running under Python 3.6.8. The required packages are a
 ## Run the Codes
 * FM
 ```
-python main_nfm.py --model_type fm --dataset amazon-book
+python main_nfm.py --model_type fm --data_name amazon-book
 ```
 * NFM
 ```
-python main_nfm.py --model_type nfm --dataset amazon-book
+python main_nfm.py --model_type nfm --data_name amazon-book
 ```
 * BPRMF *(train on multi-GPUs)*
 ```
-python -m torch.distributed.launch main_bprmf.py --dataset amazon-book
+python -m torch.distributed.launch main_bprmf.py --data_name amazon-book
 ```
 * ECFKG *(train on multi-GPUs)*
 ```
-python -m torch.distributed.launch main_ecfkg.py --dataset amazon-book
+python -m torch.distributed.launch main_ecfkg.py --data_name amazon-book
 ```
 * CKE *(train on multi-GPUs)*
 ```
-python -m torch.distributed.launch main_cke.py --dataset amazon-book
+python -m torch.distributed.launch main_cke.py --data_name amazon-book
 ```
 * KGAT
 ```
-python main_kgat.py --dataset amazon-book
+python main_kgat.py --data_name amazon-book
 ```
 
 ## Results

--- a/main_kgat.py
+++ b/main_kgat.py
@@ -111,6 +111,7 @@ def train(args):
     if use_cuda:
         train_nodes = train_nodes.to(device)
         train_edges = train_edges.to(device)
+        train_graph = train_graph.to(device)
     train_graph.ndata['id'] = train_nodes
     train_graph.edata['type'] = train_edges
 
@@ -120,6 +121,7 @@ def train(args):
     if use_cuda:
         test_nodes = test_nodes.to(device)
         test_edges = test_edges.to(device)
+        test_graph = test_graph.to(device)
     test_graph.ndata['id'] = test_nodes
     test_graph.edata['type'] = test_edges
 
@@ -262,6 +264,7 @@ def predict(args):
     if use_cuda:
         train_nodes = train_nodes.to(device)
         train_edges = train_edges.to(device)
+        train_graph = train_graph.to(device)
     train_graph.ndata['id'] = train_nodes
     train_graph.edata['type'] = train_edges
 
@@ -271,6 +274,7 @@ def predict(args):
     if use_cuda:
         test_nodes = test_nodes.to(device)
         test_edges = test_edges.to(device)
+        test_graph = test_graph.to(device)
     test_graph.ndata['id'] = test_nodes
     test_graph.edata['type'] = test_edges
 


### PR DESCRIPTION
1. DGLGraph now requires the graph structure and feature data to have the same device placement. So using `DGLGraph.to` to copy data to GPU.
2. Fixed arguments in `README.md`.
